### PR TITLE
Lobby refactor

### DIFF
--- a/cog/lobby.py
+++ b/cog/lobby.py
@@ -18,11 +18,11 @@ class Promotion:
     lobby_id: int
     game: GameModel
     original_channel: discord.TextChannel
-    date_time = datetime.now() + timedelta(seconds=10.0)
+    date_time = datetime.now() + timedelta(minutes=10.0)
     has_promoted = False
 
     def update_date_time(self):
-        self.date_time = datetime.now() + timedelta(seconds=10.0)
+        self.date_time = datetime.now() + timedelta(minutes=10.0)
 
     def __repr__(self):
         return f"Promotion: {self.lobby_id}, {self.game.game_code}, {str(self.date_time)}" \

--- a/cog/lobby.py
+++ b/cog/lobby.py
@@ -314,35 +314,6 @@ class LobbyCog(commands.Cog):
             ephemeral=True
         )
 
-    # TODO: Refactor out of this class
-    @commands.Cog.listener()
-    async def on_owner_leave(
-        self,
-        lobby_id: int,
-        interaction: discord.Interaction,
-    ):
-        lobby_owner = LobbyManager.get_lobby_owner(self.bot, lobby_id)
-        if interaction.user != lobby_owner:
-            await interaction.response.defer()
-            return
-        count = LobbyManager.get_member_length(self.bot, lobby_id)
-        if count == 1:
-            channel = LobbyManager.get_original_channel(self.bot, lobby_id)
-            await channel.send(
-                embed=UpdateMessageEmbed(
-                    title="Lobby Closed",
-                    value=f"🛑 Lobby {interaction.channel.name} has been deleted.",
-                    color=discord.Color.red()
-                )
-            )
-            await LobbyManager.delete_lobby(self.bot, lobby_id)
-        else:
-            success = await LobbyManager.remove_owner(self.bot, lobby_id)
-            if success:
-                LobbyManager.get_lobby_owner(self.bot, lobby_id)
-        interaction.client.dispatch('update_lobby_embed', lobby_id)
-        await interaction.response.defer()
-
 
 async def setup(bot):
     await bot.add_cog(LobbyCog(bot))

--- a/model/lobby_model.py
+++ b/model/lobby_model.py
@@ -50,6 +50,7 @@ class LobbyModel:
     game_code = 'gametype'
     game_size = 1
     last_promotion_message: discord.Message = None
+    is_promoting = False
     members: list[MemberModel] = field(default_factory=list)
     thread: discord.Thread = None
     status = LobbyState.UNLOCKED
@@ -333,3 +334,13 @@ class LobbyManager:
     ) -> None:
         '''Set the last promotion message'''
         bot.lobby[lobby_id].last_promotion_message = message
+
+    @staticmethod
+    def get_is_promoting(bot: commands.Bot, lobby_id: int) -> bool:
+        '''Get the is promoting state'''
+        return bot.lobby[lobby_id].is_promoting
+
+    @staticmethod
+    def set_is_promoting(bot: commands.Bot, lobby_id: int, state: bool) -> None:
+        '''Set the is promoting state'''
+        bot.lobby[lobby_id].is_promoting = state

--- a/view/lobby/button_view.py
+++ b/view/lobby/button_view.py
@@ -356,9 +356,10 @@ class ButtonView(discord.ui.View):
 
     @discord.ui.button(label="Disband", style=discord.ButtonStyle.blurple)
     async def disband(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.send_modal(
-            ConfirmationModal(self.lobby_id)
-        )
+        if interaction.user == LobbyManager.get_lobby_owner(interaction.client, self.lobby_id):
+            await interaction.response.send_modal(
+                ConfirmationModal(self.lobby_id)
+            )
 
     @discord.ui.button(label="Promote: OFF", style=discord.ButtonStyle.blurple)
     async def promote(self, interaction: discord.Interaction, button: discord.ui.Button):

--- a/view/lobby/button_view.py
+++ b/view/lobby/button_view.py
@@ -223,7 +223,6 @@ class ButtonView(discord.ui.View):
 
     @discord.ui.button(label="Leave", style=discord.ButtonStyle.red)
     async def leave(self, interaction: discord.Interaction, button: discord.ui.Button):
-        # TODO: Check if promote button is toggled, to continue promoting
         await interaction.response.defer()
         embed_type = None
         lobby_owner = LobbyManager.get_lobby_owner(

--- a/view/lobby/button_view.py
+++ b/view/lobby/button_view.py
@@ -143,7 +143,7 @@ class ButtonView(discord.ui.View):
     @discord.ui.button(label='Join', style=discord.ButtonStyle.green)
     async def join_button(self, interaction: discord.Interaction, button: discord.ui.Button,):
         if LobbyManager.has_joined(interaction.client, self.lobby_id, interaction.user):
-            interaction.response.defer()
+            await interaction.response.defer()
             return
         LobbyManager.add_member(
             interaction.client, self.lobby_id, interaction.user)

--- a/view/lobby/button_view.py
+++ b/view/lobby/button_view.py
@@ -360,6 +360,7 @@ class ButtonView(discord.ui.View):
             await interaction.response.send_modal(
                 ConfirmationModal(self.lobby_id)
             )
+        interaction.response.defer()
 
     @discord.ui.button(label="Promote: OFF", style=discord.ButtonStyle.blurple)
     async def promote(self, interaction: discord.Interaction, button: discord.ui.Button):

--- a/view/lobby/embeds.py
+++ b/view/lobby/embeds.py
@@ -149,7 +149,7 @@ class UpdateMessageEmbed(discord.Embed):
             },
             UpdateMessageEmbedType.DELETE.value: {
                 'colour': discord.Color.red(),
-                'message': 'has shut the door behind them, lobby closed!'
+                'message': 'has shut the door behind them, lobby closed! 🛑'
             }
         }
 


### PR DESCRIPTION
Improves the added lobby promotion scheduler.
- Refactored to prevent repetition.
- The promotion button gets toggled off when the lobby is full.
- Deletes the last promotion message to clean up channels.

Fixed:
- Ready button not being awaited.
- Embeds are being sent after the needed data has been long deleted.
- Removed deprecated event listener for on_lobby_owner_leave.