### PR TITLE
Truncate file name string if longer than 15 characters

### DIFF
--- a/view/soundboard/upload_submission.py
+++ b/view/soundboard/upload_submission.py
@@ -13,7 +13,7 @@ class UploadSubmission(discord.ui.Modal, title="Soundboard Submission"):
         self.file = file
         self.bite_file_path = "data/sound_bites/"
         self.temp_file_path = "data/temp/"
-        self.name_input.default = self.file.filename
+        self.name_input.default = self.file.filename[:15]
 
     name_input: discord.ui.TextInput = discord.ui.TextInput(
         label="File Name:",


### PR DESCRIPTION
- Fixed error when uploading a file with a name longer than 10 characters.
- Max length of soundbite name is now 15 characters.